### PR TITLE
アラート評価機能の追加と依存性の管理

### DIFF
--- a/ConsoleApp1/Assets/Alerting/DefaultAlertEvaluator.cs
+++ b/ConsoleApp1/Assets/Alerting/DefaultAlertEvaluator.cs
@@ -1,0 +1,42 @@
+using ConsoleApp1.Assets;
+
+namespace ConsoleApp1.Assets.Alerting
+{
+    public class DefaultAlertEvaluator : IAlertEvaluator
+    {
+        public bool ShouldAlert(AssetInfo assetInfo)
+        {
+            bool result = true;
+
+            if (assetInfo.IsFavorite || assetInfo.IsOwnedNow() || assetInfo.IsJustSold())
+            {
+                // ã≠êßí ím
+            }
+            else if (assetInfo.IsCloseToRecordDate() || assetInfo.IsRecordDate() || assetInfo.IsAfterRecordDate())
+            {
+                if (!assetInfo.IsHighYield()) result = false;
+                if (!assetInfo.LatestPrice.OversoldIndicator()) result = false;
+                if (!assetInfo.IsHighMarketCap()) result = false;
+                if (!assetInfo.IsAnnualProgressOnTrack()) result = false;
+            }
+            else if (assetInfo.IsCloseToQuarterEnd() || assetInfo.IsQuarterEnd() || assetInfo.IsAfterQuarterEnd())
+            {
+                if (!assetInfo.IsHighYield()) result = false;
+                if (!assetInfo.LatestPrice.OversoldIndicator()) result = false;
+                if (!assetInfo.IsHighMarketCap()) result = false;
+                if (!assetInfo.IsAnnualProgressOnTrack()) result = false;
+            }
+            else
+            {
+                if (!assetInfo.IsHighYield()) result = false;
+                if (!assetInfo.LatestPrice.OversoldIndicator()) result = false;
+                if (!assetInfo.IsHighMarketCap()) result = false;
+                if (!assetInfo.IsAnnualProgressOnTrack()) result = false;
+                if (!assetInfo.IsPERUndervalued(true)) result = false;
+                if (!assetInfo.IsPBRUndervalued(true)) result = false;
+            }
+
+            return result;
+        }
+    }
+}

--- a/ConsoleApp1/Assets/Alerting/IAlertEvaluator.cs
+++ b/ConsoleApp1/Assets/Alerting/IAlertEvaluator.cs
@@ -1,0 +1,7 @@
+namespace ConsoleApp1.Assets.Alerting
+{
+    public interface IAlertEvaluator
+    {
+        bool ShouldAlert(AssetInfo assetInfo);
+    }
+}

--- a/ConsoleApp1/Assets/AssetInfoDependencies.cs
+++ b/ConsoleApp1/Assets/AssetInfoDependencies.cs
@@ -1,3 +1,4 @@
+using ConsoleApp1.Assets.Alerting;
 using ConsoleApp1.Assets.Calculators;
 using ConsoleApp1.Assets.Repositories;
 using ConsoleApp1.Assets.Setups;
@@ -14,5 +15,6 @@ namespace ConsoleApp1.Assets
         public IAssetJudgementStrategy JudgementStrategy { get; set; }
         public IAssetCalculator Calculator { get; set; }
         public IAssetSetupStrategy SetupStrategy { get; set; }
+        public IAlertEvaluator AlertEvaluator { get; set; } // ’Ç‰Á
     }
 }

--- a/ConsoleApp1/Assets/AssetInfoFactory.cs
+++ b/ConsoleApp1/Assets/AssetInfoFactory.cs
@@ -1,3 +1,4 @@
+using ConsoleApp1.Assets.Alerting;
 using ConsoleApp1.Assets.Calculators;
 using ConsoleApp1.Assets.Repositories;
 using ConsoleApp1.Assets.Setups;
@@ -13,7 +14,8 @@ namespace ConsoleApp1.Assets
                 Repository = new AssetRepository(),
                 JudgementStrategy = new DefaultAssetJudgementStrategy(),
                 Calculator = new DefaultAssetCalculator(),
-                SetupStrategy = new DefaultAssetSetupStrategy()
+                SetupStrategy = new DefaultAssetSetupStrategy(),
+                AlertEvaluator = new DefaultAlertEvaluator() // í«â¡
             };
 
             // îhê∂ÉNÉâÉXÇ≤Ç∆Ç…Updater/FormatterÇêÿÇËë÷Ç¶

--- a/ConsoleApp1/Assets/IndexInfo.cs
+++ b/ConsoleApp1/Assets/IndexInfo.cs
@@ -5,6 +5,8 @@ using ConsoleApp1.ExternalSource;
 using ConsoleApp1.Output;
 using Microsoft.Extensions.Logging;
 
+namespace ConsoleApp1.Assets;
+
 public class IndexInfo : AssetInfo
 {
     // Factory以外からの直接生成を禁止

--- a/ConsoleApp1/Assets/JapaneseETFInfo.cs
+++ b/ConsoleApp1/Assets/JapaneseETFInfo.cs
@@ -5,6 +5,8 @@ using ConsoleApp1.Output;
 using Microsoft.Extensions.Logging;
 using System.Text;
 
+namespace ConsoleApp1.Assets;
+
 public class JapaneseETFInfo : AssetInfo
 {
     // Factory以外からの直接生成を禁止

--- a/ConsoleApp1/Assets/JapaneseStockInfo.cs
+++ b/ConsoleApp1/Assets/JapaneseStockInfo.cs
@@ -5,6 +5,8 @@ using ConsoleApp1.Output;
 using Microsoft.Extensions.Logging;
 using System.Text;
 
+namespace ConsoleApp1.Assets;
+
 public class JapaneseStockInfo : AssetInfo
 {
     // FactoryˆÈŠO‚©‚ç‚Ì’¼Ú¶¬‚ğ‹Ö~

--- a/ConsoleApp1/Assets/Repositories/AssetRepository.cs
+++ b/ConsoleApp1/Assets/Repositories/AssetRepository.cs
@@ -37,6 +37,11 @@ namespace ConsoleApp1.Assets.Repositories
                 };
                 result.Add(price);
             }
+
+            // ÉçÉOèoóÕÇí«â¡
+            CommonUtils.Instance.Logger.LogInformation(
+                $"[LoadHistory] code={code}, count={result.Count}");
+
             return result;
         }
 


### PR DESCRIPTION
アラート評価機能の追加と依存性の管理

`DefaultAlertEvaluator`クラスを追加し、アラート評価のロジックを実装しました。`IAlertEvaluator`インターフェースを定義し、`AssetInfo`クラスに依存性注入を行い、アラート評価のロジックを委譲しました。また、`AssetInfoDependencies`に`AlertEvaluator`プロパティを追加し、`AssetInfoFactory`でインスタンスを生成するようにしました。関連する名前空間も適切にインポートされました。

Closes #34